### PR TITLE
[don't merge] LPS-71614 Hardcode picture element in web content when adaptive media

### DIFF
--- a/adaptive-media-blogs-editor-configuration-dynamic/src/test/java/com/liferay/adaptive/media/blogs/editor/configuration/internal/AdaptiveMediaBlogsDynamicEditorConfigContributorTest.java
+++ b/adaptive-media-blogs-editor-configuration-dynamic/src/test/java/com/liferay/adaptive/media/blogs/editor/configuration/internal/AdaptiveMediaBlogsDynamicEditorConfigContributorTest.java
@@ -52,7 +52,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 /**
  * @author Sergio González
  */
-public class DynamicAdaptiveMediaBlogsEditorConfigContributorTest
+public class AdaptiveMediaBlogsDynamicEditorConfigContributorTest
 	extends PowerMockito {
 
 	@Before
@@ -107,14 +107,14 @@ public class DynamicAdaptiveMediaBlogsEditorConfigContributorTest
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			originalJSONObject.toJSONString());
 
-		DynamicAdaptiveMediaBlogsEditorConfigContributor
-			dynamicAdaptiveMediaBlogsEditorConfigContributor =
-				new DynamicAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsDynamicEditorConfigContributor
+			adaptiveMediaBlogsDynamicEditorConfigContributor =
+				new AdaptiveMediaBlogsDynamicEditorConfigContributor();
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.setItemSelector(
+		adaptiveMediaBlogsDynamicEditorConfigContributor.setItemSelector(
 			_itemSelector);
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsDynamicEditorConfigContributor.
 			populateConfigJSONObject(
 				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
 				_requestBackedPortletURLFactory);
@@ -165,14 +165,14 @@ public class DynamicAdaptiveMediaBlogsEditorConfigContributorTest
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			originalJSONObject.toJSONString());
 
-		DynamicAdaptiveMediaBlogsEditorConfigContributor
-			dynamicAdaptiveMediaBlogsEditorConfigContributor =
-				new DynamicAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsDynamicEditorConfigContributor
+			adaptiveMediaBlogsDynamicEditorConfigContributor =
+				new AdaptiveMediaBlogsDynamicEditorConfigContributor();
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.setItemSelector(
+		adaptiveMediaBlogsDynamicEditorConfigContributor.setItemSelector(
 			_itemSelector);
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsDynamicEditorConfigContributor.
 			populateConfigJSONObject(
 				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
 				_requestBackedPortletURLFactory);
@@ -186,9 +186,9 @@ public class DynamicAdaptiveMediaBlogsEditorConfigContributorTest
 	public void testAddAdaptiveMediaImageFileEntryItemSelectorReturnType()
 		throws Exception {
 
-		DynamicAdaptiveMediaBlogsEditorConfigContributor
-			dynamicAdaptiveMediaBlogsEditorConfigContributor =
-				new DynamicAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsDynamicEditorConfigContributor
+			adaptiveMediaBlogsDynamicEditorConfigContributor =
+				new AdaptiveMediaBlogsDynamicEditorConfigContributor();
 
 		BlogsItemSelectorCriterion blogsItemSelectorCriterion =
 			new BlogsItemSelectorCriterion();
@@ -197,7 +197,7 @@ public class DynamicAdaptiveMediaBlogsEditorConfigContributorTest
 			Collections.<ItemSelectorReturnType>singletonList(
 				new FileEntryItemSelectorReturnType()));
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsDynamicEditorConfigContributor.
 			addAdaptiveMediaImageFileEntryItemSelectorReturnType(
 				blogsItemSelectorCriterion);
 
@@ -224,11 +224,11 @@ public class DynamicAdaptiveMediaBlogsEditorConfigContributorTest
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			originalJSONObject.toJSONString());
 
-		DynamicAdaptiveMediaBlogsEditorConfigContributor
-			dynamicAdaptiveMediaBlogsEditorConfigContributor =
-				new DynamicAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsDynamicEditorConfigContributor
+			adaptiveMediaBlogsDynamicEditorConfigContributor =
+				new AdaptiveMediaBlogsDynamicEditorConfigContributor();
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsDynamicEditorConfigContributor.
 			populateConfigJSONObject(
 				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
 				_requestBackedPortletURLFactory);
@@ -248,11 +248,11 @@ public class DynamicAdaptiveMediaBlogsEditorConfigContributorTest
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			originalJSONObject.toJSONString());
 
-		DynamicAdaptiveMediaBlogsEditorConfigContributor
-			dynamicAdaptiveMediaBlogsEditorConfigContributor =
-				new DynamicAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsDynamicEditorConfigContributor
+			adaptiveMediaBlogsDynamicEditorConfigContributor =
+				new AdaptiveMediaBlogsDynamicEditorConfigContributor();
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsDynamicEditorConfigContributor.
 			populateConfigJSONObject(
 				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
 				_requestBackedPortletURLFactory);
@@ -277,14 +277,14 @@ public class DynamicAdaptiveMediaBlogsEditorConfigContributorTest
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			originalJSONObject.toJSONString());
 
-		DynamicAdaptiveMediaBlogsEditorConfigContributor
-			dynamicAdaptiveMediaBlogsEditorConfigContributor =
-				new DynamicAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsDynamicEditorConfigContributor
+			adaptiveMediaBlogsDynamicEditorConfigContributor =
+				new AdaptiveMediaBlogsDynamicEditorConfigContributor();
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.setItemSelector(
+		adaptiveMediaBlogsDynamicEditorConfigContributor.setItemSelector(
 			_itemSelector);
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsDynamicEditorConfigContributor.
 			populateConfigJSONObject(
 				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
 				_requestBackedPortletURLFactory);
@@ -324,14 +324,14 @@ public class DynamicAdaptiveMediaBlogsEditorConfigContributorTest
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			originalJSONObject.toJSONString());
 
-		DynamicAdaptiveMediaBlogsEditorConfigContributor
-			dynamicAdaptiveMediaBlogsEditorConfigContributor =
-				new DynamicAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsDynamicEditorConfigContributor
+			adaptiveMediaBlogsDynamicEditorConfigContributor =
+				new AdaptiveMediaBlogsDynamicEditorConfigContributor();
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.setItemSelector(
+		adaptiveMediaBlogsDynamicEditorConfigContributor.setItemSelector(
 			_itemSelector);
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsDynamicEditorConfigContributor.
 			populateConfigJSONObject(
 				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
 				_requestBackedPortletURLFactory);
@@ -393,14 +393,14 @@ public class DynamicAdaptiveMediaBlogsEditorConfigContributorTest
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			originalJSONObject.toJSONString());
 
-		DynamicAdaptiveMediaBlogsEditorConfigContributor
-			dynamicAdaptiveMediaBlogsEditorConfigContributor =
-				new DynamicAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsDynamicEditorConfigContributor
+			adaptiveMediaBlogsDynamicEditorConfigContributor =
+				new AdaptiveMediaBlogsDynamicEditorConfigContributor();
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.setItemSelector(
+		adaptiveMediaBlogsDynamicEditorConfigContributor.setItemSelector(
 			_itemSelector);
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsDynamicEditorConfigContributor.
 			populateConfigJSONObject(
 				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
 				_requestBackedPortletURLFactory);
@@ -454,14 +454,14 @@ public class DynamicAdaptiveMediaBlogsEditorConfigContributorTest
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			originalJSONObject.toJSONString());
 
-		DynamicAdaptiveMediaBlogsEditorConfigContributor
-			dynamicAdaptiveMediaBlogsEditorConfigContributor =
-				new DynamicAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsDynamicEditorConfigContributor
+			adaptiveMediaBlogsDynamicEditorConfigContributor =
+				new AdaptiveMediaBlogsDynamicEditorConfigContributor();
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.setItemSelector(
+		adaptiveMediaBlogsDynamicEditorConfigContributor.setItemSelector(
 			_itemSelector);
 
-		dynamicAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsDynamicEditorConfigContributor.
 			populateConfigJSONObject(
 				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
 				_requestBackedPortletURLFactory);

--- a/adaptive-media-blogs-editor-configuration-static/src/test/java/com/liferay/adaptive/media/blogs/editor/configuration/internal/AdaptiveMediaBlogsStaticEditorConfigContributorTest.java
+++ b/adaptive-media-blogs-editor-configuration-static/src/test/java/com/liferay/adaptive/media/blogs/editor/configuration/internal/AdaptiveMediaBlogsStaticEditorConfigContributorTest.java
@@ -53,7 +53,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 /**
  * @author Alejandro Tardín
  */
-public class StaticAdaptiveMediaBlogsEditorConfigContributorTest
+public class AdaptiveMediaBlogsStaticEditorConfigContributorTest
 	extends PowerMockito {
 
 	@Before
@@ -79,11 +79,11 @@ public class StaticAdaptiveMediaBlogsEditorConfigContributorTest
 			Collections.<ItemSelectorReturnType>singletonList(
 				new URLItemSelectorReturnType()));
 
-		StaticAdaptiveMediaBlogsEditorConfigContributor
-			staticAdaptiveMediaBlogsEditorConfigContributor =
-				new StaticAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsStaticEditorConfigContributor
+			adaptiveMediaBlogsStaticEditorConfigContributor =
+				new AdaptiveMediaBlogsStaticEditorConfigContributor();
 
-		staticAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsStaticEditorConfigContributor.
 			addAdaptiveMediaImageURLItemSelectorReturnType(
 				blogsItemSelectorCriterion);
 
@@ -179,14 +179,14 @@ public class StaticAdaptiveMediaBlogsEditorConfigContributorTest
 			Collections.<ItemSelectorCriterion>emptyList()
 		);
 
-		StaticAdaptiveMediaBlogsEditorConfigContributor
-			staticAdaptiveMediaBlogsEditorConfigContributor =
-				new StaticAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsStaticEditorConfigContributor
+			adaptiveMediaBlogsStaticEditorConfigContributor =
+				new AdaptiveMediaBlogsStaticEditorConfigContributor();
 
-		staticAdaptiveMediaBlogsEditorConfigContributor.setItemSelector(
+		adaptiveMediaBlogsStaticEditorConfigContributor.setItemSelector(
 			_itemSelector);
 
-		staticAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsStaticEditorConfigContributor.
 			populateConfigJSONObject(
 				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
 				_requestBackedPortletURLFactory);
@@ -245,14 +245,14 @@ public class StaticAdaptiveMediaBlogsEditorConfigContributorTest
 		JSONObject expectedJSONObject = JSONFactoryUtil.createJSONObject(
 			originalJSONObject.toJSONString());
 
-		StaticAdaptiveMediaBlogsEditorConfigContributor
-			staticAdaptiveMediaBlogsEditorConfigContributor =
-				new StaticAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsStaticEditorConfigContributor
+			adaptiveMediaBlogsStaticEditorConfigContributor =
+				new AdaptiveMediaBlogsStaticEditorConfigContributor();
 
-		staticAdaptiveMediaBlogsEditorConfigContributor.setItemSelector(
+		adaptiveMediaBlogsStaticEditorConfigContributor.setItemSelector(
 			_itemSelector);
 
-		staticAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsStaticEditorConfigContributor.
 			populateConfigJSONObject(
 				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
 				_requestBackedPortletURLFactory);
@@ -275,11 +275,11 @@ public class StaticAdaptiveMediaBlogsEditorConfigContributorTest
 		JSONObject expectedJSONObject = JSONFactoryUtil.createJSONObject(
 			originalJSONObject.toJSONString());
 
-		StaticAdaptiveMediaBlogsEditorConfigContributor
-			staticAdaptiveMediaBlogsEditorConfigContributor =
-				new StaticAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsStaticEditorConfigContributor
+			adaptiveMediaBlogsStaticEditorConfigContributor =
+				new AdaptiveMediaBlogsStaticEditorConfigContributor();
 
-		staticAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsStaticEditorConfigContributor.
 			populateConfigJSONObject(
 				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
 				_requestBackedPortletURLFactory);
@@ -388,14 +388,14 @@ public class StaticAdaptiveMediaBlogsEditorConfigContributorTest
 		expectedJSONObject.put(
 			"filebrowserImageBrowseUrl", itemSelectorPortletURL.toString());
 
-		StaticAdaptiveMediaBlogsEditorConfigContributor
-			staticAdaptiveMediaBlogsEditorConfigContributor =
-				new StaticAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsStaticEditorConfigContributor
+			adaptiveMediaBlogsStaticEditorConfigContributor =
+				new AdaptiveMediaBlogsStaticEditorConfigContributor();
 
-		staticAdaptiveMediaBlogsEditorConfigContributor.setItemSelector(
+		adaptiveMediaBlogsStaticEditorConfigContributor.setItemSelector(
 			_itemSelector);
 
-		staticAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsStaticEditorConfigContributor.
 			populateConfigJSONObject(
 				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
 				_requestBackedPortletURLFactory);
@@ -456,14 +456,14 @@ public class StaticAdaptiveMediaBlogsEditorConfigContributorTest
 		expectedJSONObject.put(
 			"filebrowserImageBrowseUrl", itemSelectorPortletURL.toString());
 
-		StaticAdaptiveMediaBlogsEditorConfigContributor
-			staticAdaptiveMediaBlogsEditorConfigContributor =
-				new StaticAdaptiveMediaBlogsEditorConfigContributor();
+		AdaptiveMediaBlogsStaticEditorConfigContributor
+			adaptiveMediaBlogsStaticEditorConfigContributor =
+				new AdaptiveMediaBlogsStaticEditorConfigContributor();
 
-		staticAdaptiveMediaBlogsEditorConfigContributor.setItemSelector(
+		adaptiveMediaBlogsStaticEditorConfigContributor.setItemSelector(
 			_itemSelector);
 
-		staticAdaptiveMediaBlogsEditorConfigContributor.
+		adaptiveMediaBlogsStaticEditorConfigContributor.
 			populateConfigJSONObject(
 				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
 				_requestBackedPortletURLFactory);

--- a/adaptive-media-journal-editor-configuration-static/bnd.bnd
+++ b/adaptive-media-journal-editor-configuration-static/bnd.bnd
@@ -1,0 +1,6 @@
+Bundle-Name: Liferay Adaptive Media Journal Editor Configuration Static
+Bundle-SymbolicName: com.liferay.adaptive.media.journal.editor.configuration.static
+Bundle-Version: 1.0.0
+Liferay-Releng-Module-Group-Description:
+Liferay-Releng-Module-Group-Title: Adaptive Media
+-dsannotations-options: inherit

--- a/adaptive-media-journal-editor-configuration-static/build.gradle
+++ b/adaptive-media-journal-editor-configuration-static/build.gradle
@@ -1,0 +1,18 @@
+dependencies {
+	provided group: "com.liferay", name: "com.liferay.blogs.item.selector.api", version: "1.0.0"
+	provided group: "com.liferay", name: "com.liferay.item.selector.api", version: "2.2.0"
+	provided group: "com.liferay", name: "com.liferay.item.selector.criteria.api", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.journal.api", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
+	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
+	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:adaptive-media:adaptive-media-image-item-selector-api");
+
+	testCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	testCompile group: "org.jabsorb", name: "jabsorb", version: "1.3.1"
+	testCompile group: "org.jodd", name: "jodd-bean", version: "3.6.4"
+	testCompile group: "org.jodd", name: "jodd-core", version: "3.6.4"
+	testCompile group: "org.jodd", name: "jodd-json", version: "3.6.4"
+	testCompile group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"
+	testCompile group: "org.slf4j", name: "slf4j-api", version: "1.7.22"
+}

--- a/adaptive-media-journal-editor-configuration-static/src/main/java/com/liferay/adaptive/media/journal/editor/configuration/internal/AdaptiveMediaJournalStaticEditorConfigContributor.java
+++ b/adaptive-media-journal-editor-configuration-static/src/main/java/com/liferay/adaptive/media/journal/editor/configuration/internal/AdaptiveMediaJournalStaticEditorConfigContributor.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.adaptive.media.journal.editor.configuration.internal;
+
+import com.liferay.adaptive.media.image.item.selector.AdaptiveMediaImageURLItemSelectorReturnType;
+import com.liferay.item.selector.ItemSelector;
+import com.liferay.item.selector.ItemSelectorCriterion;
+import com.liferay.item.selector.ItemSelectorReturnType;
+import com.liferay.item.selector.criteria.file.criterion.FileItemSelectorCriterion;
+import com.liferay.item.selector.criteria.image.criterion.ImageItemSelectorCriterion;
+import com.liferay.item.selector.criteria.upload.criterion.UploadItemSelectorCriterion;
+import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.PortletURL;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Sergio González
+ */
+@Component(
+	property = {
+		"editor.name=alloyeditor", "editor.name=ckeditor",
+		"javax.portlet.name=" + JournalPortletKeys.JOURNAL,
+		"service.ranking:Integer=100"
+	},
+	service = EditorConfigContributor.class
+)
+public class AdaptiveMediaJournalStaticEditorConfigContributor
+	extends BaseEditorConfigContributor {
+
+	@Override
+	public void populateConfigJSONObject(
+		JSONObject jsonObject, Map<String, Object> inputEditorTaglibAttributes,
+		ThemeDisplay themeDisplay,
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		String extraPlugins = jsonObject.getString("extraPlugins");
+
+		if (StringUtil.contains(extraPlugins, "adaptivemedia")) {
+			return;
+		}
+
+		String itemSelectorURL = jsonObject.getString(
+			"filebrowserImageBrowseLinkUrl");
+
+		if (Validator.isNull(itemSelectorURL)) {
+			return;
+		}
+
+		List<ItemSelectorCriterion> itemSelectorCriteria =
+			_itemSelector.getItemSelectorCriteria(itemSelectorURL);
+
+		boolean adaptiveMediaImageURLItemSelectorReturnTypeAdded = false;
+
+		for (ItemSelectorCriterion itemSelectorCriterion :
+				itemSelectorCriteria) {
+
+			if (itemSelectorCriterion instanceof FileItemSelectorCriterion ||
+				itemSelectorCriterion instanceof ImageItemSelectorCriterion ||
+				itemSelectorCriterion instanceof UploadItemSelectorCriterion) {
+
+				addAdaptiveMediaImageURLItemSelectorReturnType(
+					itemSelectorCriterion);
+
+				adaptiveMediaImageURLItemSelectorReturnTypeAdded = true;
+			}
+		}
+
+		if (!adaptiveMediaImageURLItemSelectorReturnTypeAdded) {
+			return;
+		}
+
+		if (Validator.isNotNull(extraPlugins)) {
+			extraPlugins = extraPlugins + ",adaptivemedia";
+		}
+		else {
+			extraPlugins = "adaptivemedia";
+		}
+
+		jsonObject.put("extraPlugins", extraPlugins);
+
+		String itemSelectedEventName = _itemSelector.getItemSelectedEventName(
+			itemSelectorURL);
+
+		PortletURL itemSelectorPortletURL = _itemSelector.getItemSelectorURL(
+			requestBackedPortletURLFactory, itemSelectedEventName,
+			itemSelectorCriteria.toArray(
+				new ItemSelectorCriterion[itemSelectorCriteria.size()]));
+
+		jsonObject.put(
+			"filebrowserImageBrowseLinkUrl", itemSelectorPortletURL.toString());
+		jsonObject.put(
+			"filebrowserImageBrowseUrl", itemSelectorPortletURL.toString());
+
+		_allowTagRule(jsonObject, _PICTURE_TAG_RULE);
+		_allowTagRule(jsonObject, _IMG_TAG_RULE);
+	}
+
+	@Reference(unbind = "-")
+	public void setItemSelector(ItemSelector itemSelector) {
+		_itemSelector = itemSelector;
+	}
+
+	protected void addAdaptiveMediaImageURLItemSelectorReturnType(
+		ItemSelectorCriterion itemSelectorCriterion) {
+
+		List<ItemSelectorReturnType> desiredItemSelectorReturnTypes =
+			new ArrayList<>();
+
+		desiredItemSelectorReturnTypes.add(
+			new AdaptiveMediaImageURLItemSelectorReturnType());
+		desiredItemSelectorReturnTypes.addAll(
+			itemSelectorCriterion.getDesiredItemSelectorReturnTypes());
+
+		itemSelectorCriterion.setDesiredItemSelectorReturnTypes(
+			desiredItemSelectorReturnTypes);
+	}
+
+	private void _allowTagRule(JSONObject jsonObject, String tagRule) {
+		String allowedContent = jsonObject.getString("allowedContent");
+
+		if (Validator.isNotNull(allowedContent)) {
+			allowedContent += StringPool.SPACE + tagRule;
+		}
+		else {
+			allowedContent = tagRule;
+		}
+
+		jsonObject.put("allowedContent", allowedContent);
+	}
+
+	private static final String _IMG_TAG_RULE = "img[*](*);";
+
+	private static final String _PICTURE_TAG_RULE =
+		"picture[*](*); source[*](*);";
+
+	private ItemSelector _itemSelector;
+
+}

--- a/adaptive-media-journal-editor-configuration-static/src/test/java/com/liferay/adaptive/media/journal/editor/configuration/internal/AdaptiveMediaJournalStaticEditorConfigContributorTest.java
+++ b/adaptive-media-journal-editor-configuration-static/src/test/java/com/liferay/adaptive/media/journal/editor/configuration/internal/AdaptiveMediaJournalStaticEditorConfigContributorTest.java
@@ -1,0 +1,471 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.adaptive.media.journal.editor.configuration.internal;
+
+import com.liferay.adaptive.media.image.item.selector.AdaptiveMediaImageURLItemSelectorReturnType;
+import com.liferay.blogs.item.selector.criterion.BlogsItemSelectorCriterion;
+import com.liferay.item.selector.ItemSelector;
+import com.liferay.item.selector.ItemSelectorCriterion;
+import com.liferay.item.selector.ItemSelectorReturnType;
+import com.liferay.item.selector.criteria.URLItemSelectorReturnType;
+import com.liferay.item.selector.criteria.file.criterion.FileItemSelectorCriterion;
+import com.liferay.item.selector.criteria.image.criterion.ImageItemSelectorCriterion;
+import com.liferay.item.selector.criteria.upload.criterion.UploadItemSelectorCriterion;
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.PortletURL;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import org.powermock.api.mockito.PowerMockito;
+
+import org.skyscreamer.jsonassert.JSONAssert;
+
+/**
+ * @author Sergio González
+ */
+public class AdaptiveMediaJournalStaticEditorConfigContributorTest
+	extends PowerMockito {
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+
+		_inputEditorTaglibAttributes.put(
+			"liferay-ui:input-editor:name", "testEditor");
+	}
+
+	@Test
+	public void testAddAdaptiveMediaImageURLItemSelectorReturnType()
+		throws Exception {
+
+		BlogsItemSelectorCriterion blogsItemSelectorCriterion =
+			new BlogsItemSelectorCriterion();
+
+		blogsItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
+			Collections.<ItemSelectorReturnType>singletonList(
+				new URLItemSelectorReturnType()));
+
+		AdaptiveMediaJournalStaticEditorConfigContributor
+			adaptiveMediaJournalStaticEditorConfigContributor =
+				new AdaptiveMediaJournalStaticEditorConfigContributor();
+
+		adaptiveMediaJournalStaticEditorConfigContributor.
+			addAdaptiveMediaImageURLItemSelectorReturnType(
+				blogsItemSelectorCriterion);
+
+		List<ItemSelectorReturnType> desiredItemSelectorReturnTypes =
+			blogsItemSelectorCriterion.getDesiredItemSelectorReturnTypes();
+
+		Assert.assertEquals(
+			desiredItemSelectorReturnTypes.toString(), 2,
+			desiredItemSelectorReturnTypes.size());
+		Assert.assertTrue(
+			desiredItemSelectorReturnTypes.get(0) instanceof
+				AdaptiveMediaImageURLItemSelectorReturnType);
+		Assert.assertTrue(
+			desiredItemSelectorReturnTypes.get(1) instanceof
+				URLItemSelectorReturnType);
+	}
+
+	@Test
+	public void testAddsPictureAndSourceAndImageAreAddedToAllowedContentForImage()
+		throws Exception {
+
+		_testAddsPictureAndImgTagToAllowedContent(
+			_getItemSelectorCriterion(ImageItemSelectorCriterion.class));
+	}
+
+	@Test
+	public void testAddsPictureAndSourceAndImgAreAddedToAllowedContentForFile()
+		throws Exception {
+
+		_testAddsPictureAndImgTagToAllowedContent(
+			_getItemSelectorCriterion(FileItemSelectorCriterion.class));
+	}
+
+	@Test
+	public void testAddsPictureAndSourceAreAddedToAllowedContentForUpload()
+		throws Exception {
+
+		_testSetsPictureAndImgTagToAllowedContent(
+			_getItemSelectorCriterion(UploadItemSelectorCriterion.class));
+	}
+
+	@Test
+	public void testDoesNothingForUnsupportedItemSelectorCriterion()
+		throws Exception {
+
+		JSONObject originalJSONObject = JSONFactoryUtil.createJSONObject();
+
+		originalJSONObject.put("allowedContent", "a[*](*); div(*);");
+		originalJSONObject.put(
+			"filebrowserImageBrowseLinkUrl",
+			"fileItemSelectorCriterionFileEntryItemSelectorReturnType");
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			originalJSONObject.toJSONString());
+
+		JSONObject expectedJSONObject = JSONFactoryUtil.createJSONObject(
+			originalJSONObject.toJSONString());
+
+		PortletURL itemSelectorPortletURL = mock(PortletURL.class);
+
+		when(
+			itemSelectorPortletURL.toString()
+		).thenReturn(
+			"itemSelectorPortletURL"
+		);
+
+		when(
+			_itemSelector.getItemSelectorURL(
+				Mockito.any(RequestBackedPortletURLFactory.class),
+				Mockito.anyString(), Mockito.any(ItemSelectorCriterion.class))
+		).thenReturn(
+			itemSelectorPortletURL
+		);
+
+		when(
+			_itemSelector.getItemSelectedEventName(Mockito.anyString())
+		).thenReturn(
+			"selectedEventName"
+		);
+
+		when(
+			_itemSelector.getItemSelectorCriteria(
+				"fileItemSelectorCriterionFileEntryItemSelectorReturnType")
+		).thenReturn(
+			Collections.<ItemSelectorCriterion>emptyList()
+		);
+
+		AdaptiveMediaJournalStaticEditorConfigContributor
+			adaptiveMediaJournalStaticEditorConfigContributor =
+				new AdaptiveMediaJournalStaticEditorConfigContributor();
+
+		adaptiveMediaJournalStaticEditorConfigContributor.setItemSelector(
+			_itemSelector);
+
+		adaptiveMediaJournalStaticEditorConfigContributor.
+			populateConfigJSONObject(
+				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
+				_requestBackedPortletURLFactory);
+
+		JSONAssert.assertEquals(
+			expectedJSONObject.toJSONString(), jsonObject.toJSONString(), true);
+	}
+
+	@Test
+	public void testDoesNothingIfTheAdaptiveMediaPluginHasAlreadyBeenAdded()
+		throws Exception {
+
+		PortletURL itemSelectorPortletURL = mock(PortletURL.class);
+
+		when(
+			itemSelectorPortletURL.toString()
+		).thenReturn(
+			"itemSelectorPortletURL"
+		);
+
+		when(
+			_itemSelector.getItemSelectorURL(
+				Mockito.any(RequestBackedPortletURLFactory.class),
+				Mockito.anyString(), Mockito.any(ItemSelectorCriterion.class))
+		).thenReturn(
+			itemSelectorPortletURL
+		);
+
+		when(
+			_itemSelector.getItemSelectedEventName(Mockito.anyString())
+		).thenReturn(
+			"selectedEventName"
+		);
+
+		ItemSelectorCriterion itemSelectorCriterion = _getItemSelectorCriterion(
+			FileItemSelectorCriterion.class);
+
+		when(
+			_itemSelector.getItemSelectorCriteria(
+				"fileItemSelectorCriterionFileEntryItemSelectorReturnType")
+		).thenReturn(
+			Arrays.asList(itemSelectorCriterion)
+		);
+
+		JSONObject originalJSONObject = JSONFactoryUtil.createJSONObject();
+
+		originalJSONObject.put("allowedContent", "a[*](*); div(*);");
+		originalJSONObject.put("extraPlugins", "adaptivemedia");
+		originalJSONObject.put(
+			"filebrowserImageBrowseLinkUrl",
+			"fileItemSelectorCriterionFileEntryItemSelectorReturnType");
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			originalJSONObject.toJSONString());
+
+		JSONObject expectedJSONObject = JSONFactoryUtil.createJSONObject(
+			originalJSONObject.toJSONString());
+
+		AdaptiveMediaJournalStaticEditorConfigContributor
+			adaptiveMediaJournalStaticEditorConfigContributor =
+				new AdaptiveMediaJournalStaticEditorConfigContributor();
+
+		adaptiveMediaJournalStaticEditorConfigContributor.setItemSelector(
+			_itemSelector);
+
+		adaptiveMediaJournalStaticEditorConfigContributor.
+			populateConfigJSONObject(
+				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
+				_requestBackedPortletURLFactory);
+
+		JSONAssert.assertEquals(
+			expectedJSONObject.toJSONString(), jsonObject.toJSONString(), true);
+	}
+
+	@Test
+	public void testDoesNothingIfThereIsNotFileBrowserImageBrowseLinkUrl()
+		throws Exception {
+
+		JSONObject originalJSONObject = JSONFactoryUtil.createJSONObject();
+
+		originalJSONObject.put("allowedContent", "a[*](*); div(*);");
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			originalJSONObject.toJSONString());
+
+		JSONObject expectedJSONObject = JSONFactoryUtil.createJSONObject(
+			originalJSONObject.toJSONString());
+
+		AdaptiveMediaJournalStaticEditorConfigContributor
+			adaptiveMediaJournalStaticEditorConfigContributor =
+				new AdaptiveMediaJournalStaticEditorConfigContributor();
+
+		adaptiveMediaJournalStaticEditorConfigContributor.
+			populateConfigJSONObject(
+				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
+				_requestBackedPortletURLFactory);
+
+		JSONAssert.assertEquals(
+			expectedJSONObject.toJSONString(), jsonObject.toJSONString(), true);
+	}
+
+	@Test
+	public void testSetsPictureAndSourceAndImgAreAddedToAllowedContentForFile()
+		throws Exception {
+
+		_testSetsPictureAndImgTagToAllowedContent(
+			_getItemSelectorCriterion(FileItemSelectorCriterion.class));
+	}
+
+	@Test
+	public void testSetsPictureAndSourceAndImgAreAddedToAllowedContentForImage()
+		throws Exception {
+
+		_testSetsPictureAndImgTagToAllowedContent(
+			_getItemSelectorCriterion(ImageItemSelectorCriterion.class));
+	}
+
+	@Test
+	public void testSetsPictureAndSourceAreAddedToAllowedContentForUpload()
+		throws Exception {
+
+		_testSetsPictureAndImgTagToAllowedContent(
+			_getItemSelectorCriterion(UploadItemSelectorCriterion.class));
+	}
+
+	private ItemSelectorCriterion _getItemSelectorCriterion(
+			Class<? extends ItemSelectorCriterion> itemSelectorCriterionClass)
+		throws IllegalAccessException, InstantiationException {
+
+		ItemSelectorCriterion itemSelectorCriterion =
+			itemSelectorCriterionClass.newInstance();
+
+		itemSelectorCriterion.setDesiredItemSelectorReturnTypes(
+			new ArrayList<ItemSelectorReturnType>());
+
+		return itemSelectorCriterion;
+	}
+
+	private void _testAddsPictureAndImgTagToAllowedContent(
+			ItemSelectorCriterion itemSelectorCriterion)
+		throws Exception {
+
+		PortletURL itemSelectorPortletURL = mock(PortletURL.class);
+
+		when(
+			itemSelectorPortletURL.toString()
+		).thenReturn(
+			"itemSelectorPortletURL"
+		);
+
+		when(
+			_itemSelector.getItemSelectorURL(
+				Mockito.any(RequestBackedPortletURLFactory.class),
+				Mockito.anyString(), Mockito.any(ItemSelectorCriterion.class))
+		).thenReturn(
+			itemSelectorPortletURL
+		);
+
+		when(
+			_itemSelector.getItemSelectedEventName(Mockito.anyString())
+		).thenReturn(
+			"selectedEventName"
+		);
+
+		when(
+			_itemSelector.getItemSelectorCriteria(
+				"fileItemSelectorCriterionFileEntryItemSelectorReturnType")
+		).thenReturn(
+			Arrays.asList(itemSelectorCriterion)
+		);
+
+		JSONObject originalJSONObject = JSONFactoryUtil.createJSONObject();
+
+		originalJSONObject.put("allowedContent", "a[*](*); div(*);");
+		originalJSONObject.put(
+			"filebrowserImageBrowseLinkUrl",
+			"fileItemSelectorCriterionFileEntryItemSelectorReturnType");
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			originalJSONObject.toJSONString());
+
+		JSONObject expectedJSONObject = JSONFactoryUtil.createJSONObject(
+			originalJSONObject.toJSONString());
+
+		expectedJSONObject.put(
+			"allowedContent",
+			"a[*](*); div(*); picture[*](*); source[*](*); img[*](*);");
+		expectedJSONObject.put("extraPlugins", "adaptivemedia");
+		expectedJSONObject.put(
+			"filebrowserImageBrowseLinkUrl", itemSelectorPortletURL.toString());
+		expectedJSONObject.put(
+			"filebrowserImageBrowseUrl", itemSelectorPortletURL.toString());
+
+		AdaptiveMediaJournalStaticEditorConfigContributor
+			adaptiveMediaJournalStaticEditorConfigContributor =
+				new AdaptiveMediaJournalStaticEditorConfigContributor();
+
+		adaptiveMediaJournalStaticEditorConfigContributor.setItemSelector(
+			_itemSelector);
+
+		adaptiveMediaJournalStaticEditorConfigContributor.
+			populateConfigJSONObject(
+				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
+				_requestBackedPortletURLFactory);
+
+		JSONAssert.assertEquals(
+			expectedJSONObject.toJSONString(), jsonObject.toJSONString(), true);
+	}
+
+	private void _testSetsPictureAndImgTagToAllowedContent(
+			ItemSelectorCriterion itemSelectorCriterion)
+		throws Exception {
+
+		PortletURL itemSelectorPortletURL = mock(PortletURL.class);
+
+		when(
+			itemSelectorPortletURL.toString()
+		).thenReturn(
+			"itemSelectorPortletURL"
+		);
+
+		when(
+			_itemSelector.getItemSelectorURL(
+				Mockito.any(RequestBackedPortletURLFactory.class),
+				Mockito.anyString(), Mockito.any(ItemSelectorCriterion.class))
+		).thenReturn(
+			itemSelectorPortletURL
+		);
+
+		when(
+			_itemSelector.getItemSelectedEventName(Mockito.anyString())
+		).thenReturn(
+			"selectedEventName"
+		);
+
+		when(
+			_itemSelector.getItemSelectorCriteria(
+				"fileItemSelectorCriterionFileEntryItemSelectorReturnType")
+		).thenReturn(
+			Arrays.asList(itemSelectorCriterion)
+		);
+
+		JSONObject originalJSONObject = JSONFactoryUtil.createJSONObject();
+
+		originalJSONObject.put(
+			"filebrowserImageBrowseLinkUrl",
+			"fileItemSelectorCriterionFileEntryItemSelectorReturnType");
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			originalJSONObject.toJSONString());
+
+		JSONObject expectedJSONObject = JSONFactoryUtil.createJSONObject();
+
+		expectedJSONObject.put(
+			"allowedContent", "picture[*](*); source[*](*); img[*](*);");
+		expectedJSONObject.put("extraPlugins", "adaptivemedia");
+		expectedJSONObject.put(
+			"filebrowserImageBrowseLinkUrl", itemSelectorPortletURL.toString());
+		expectedJSONObject.put(
+			"filebrowserImageBrowseUrl", itemSelectorPortletURL.toString());
+
+		AdaptiveMediaJournalStaticEditorConfigContributor
+			adaptiveMediaJournalStaticEditorConfigContributor =
+				new AdaptiveMediaJournalStaticEditorConfigContributor();
+
+		adaptiveMediaJournalStaticEditorConfigContributor.setItemSelector(
+			_itemSelector);
+
+		adaptiveMediaJournalStaticEditorConfigContributor.
+			populateConfigJSONObject(
+				jsonObject, _inputEditorTaglibAttributes, _themeDisplay,
+				_requestBackedPortletURLFactory);
+
+		JSONAssert.assertEquals(
+			expectedJSONObject.toJSONString(), jsonObject.toJSONString(), true);
+	}
+
+	private final Map<String, Object> _inputEditorTaglibAttributes =
+		new HashMap<>();
+
+	@Mock
+	private ItemSelector _itemSelector;
+
+	@Mock
+	private RequestBackedPortletURLFactory _requestBackedPortletURLFactory;
+
+	@Mock
+	private ThemeDisplay _themeDisplay;
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -299,6 +299,25 @@ task coverageReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
 	doFirst {
 		executionData = files(executionData.findAll { it.exists() })
 	}
+
+	afterEvaluate {
+		classDirectories = files(classDirectories.files.collect {
+			fileTree(
+				dir: it,
+				exclude: [
+					'**/*Exception*',
+					'**/*ServiceUtil*',
+					'**/*ServiceWrapper*',
+					'**/constants/*',
+					'**/exception/*',
+					'**/model/*',
+					'**/model/impl/*',
+					'**/persistence/*',
+					'**/service/base/*',
+					'**/service/util/*'
+				])
+		})
+	}
 }
 
 tasks.coveralls {


### PR DESCRIPTION
Adolfo, esta es una pull que no estoy seguro de si queremos mergear. He estado hablando con Jose Ignacio sobre el comportamiento que quieren para Web Content (si estático hardcodeando las urls en un elemento picture o dinámico utilizando un atributo data en la imagen y reemplazarlo al vuelo en el renderizado).

Él se inclina a pensar que prefieren el comportamiento dinámico, pero habría que hablarlo con Eudaldo para confirmarlo y ver que es posible. Ellos creo que tienen una capa intermedia entre lo que se guarda y lo que se renderiza (un ContentTransformer o algo así) que Adaptive Media podría extender para hacer el reemplazado dinámico. 

Esta pull lo único que hace es que cuando se selecciona una imagen de la Documents and Media para que se añada al contenido de un Web Content se incluye un elemento picture con todas las urls y las media queries en base a las resoluciones. 

Sin embargo, si al final deciden que sólo quieren el comportamiento dinámico, a lo mejor no tiene sentido incluir este módulo y deberíamos dejar sólo el dinámico.

